### PR TITLE
Re-try twice on 429 errors

### DIFF
--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -20,7 +20,7 @@ time_range = TimeRange(args.start_time, args.end_time)
 
 # Nice slack API wrapper
 with Session() as session:
-  slack = Slacker(args.token, session=session)
+  slack = Slacker(args.token, session=session, rate_limit_retries=2)
 
 # So we can print slack's object beautifully
 pp = pprint.PrettyPrinter(indent=4)


### PR DESCRIPTION
The underlying slacker library can now retry on 429 errors after the Slack API's suggested backup time, see https://github.com/os/slacker/pull/123/files.

This change retries two times before raising the error.