### PR TITLE
Added routine for botname filter

### DIFF
--- a/slack_cleaner/__init__.py
+++ b/slack_cleaner/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Lin, Ke-fei, Samuel Gratzl'
 __authoremail__ = 'kfei@kfei.net, samuel_gratzl@gmx.at'
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -128,6 +128,10 @@ def clean_channel(channel_id, channel_type, time_range, user_id=None, bot=False)
 
         # Delete bot messages
         if bot and (m.get('subtype') == 'bot_message' or 'bot_id' in m):
+          # If botname specified conditionalise the match
+          if args.botname:
+            if m.get('username') != user_id:
+              continue
           delete_message_on_channel(channel_id, m)
 
       # Exceptions
@@ -342,6 +346,9 @@ def resolve_user():
 
     if _user_id is None:
       sys.exit('User not found')
+  # For bots the username is customisable and can be any name
+  if args.botname:
+    _user_id = args.botname
   return _user_id
 
 


### PR DESCRIPTION
This PR adds the routines to allow the botname parameter to be used with the bot parameter to only delete messages posted with a specified username (custom bot name). previously this function was not available.