### PR TITLE
add minimum version for slacker dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
 
     install_requires=[
         'setuptools',
-        'slacker',
+        'slacker>=0.13',
         'colorama',
         ] + install_requires,
 


### PR DESCRIPTION
slack-cleaner requires 0.13 or greater at present.