### PR TITLE
Fix env var naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ usage: slack-cleaner [-h] --token TOKEN [--log] [--quiet] [--rate RATE]
 
 optional arguments:
   -h, --help           show this help message and exit
-  --token TOKEN        Slack API token (https://api.slack.com/web) or SLACK_CLEANER env var
+  --token TOKEN        Slack API token (https://api.slack.com/web) or SLACK_TOKEN env var
   --log                Create a log file in the current directory
   --quiet              Run quietly, does not log messages deleted
   --proxy              Proxy Server url:port

--- a/slack_cleaner/args.py
+++ b/slack_cleaner/args.py
@@ -12,7 +12,7 @@ class Args():
     env_token = os.environ.get('SLACK_TOKEN', None)
     p.add_argument('--token', required=not env_token,
                    default=env_token,
-                   help='Slack API token (https://api.slack.com/web) or SLACK_CLEANER env var')
+                   help='Slack API token (https://api.slack.com/web) or SLACK_TOKEN env var')
 
     # Log
     p.add_argument('--log', action='store_true',


### PR DESCRIPTION
Env var SLACK_TOKEN was referenced as SLACK_CLEANER in README.md and args.py.