### PR TITLE
Fix nested "lookup" of members list

### DIFF
--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -330,7 +330,7 @@ def get_mpdirect_ids_by_pattern(pattern):
 
   regex = re.compile('^' + pattern + '$', re.I)
   def matches(members):
-    names = [get_user(m) for m in mpims['members']]
+    names = [get_user(m) for m in members]
     # has to match at least one permutation of the members
     for permutation in itertools.permutations(names):
       if (regex.match(','.join(permutation))):


### PR DESCRIPTION
When attempting to delete multi-party direct messages, a nested lookup for the members occurs, which causes the following error due to looking up by string the second time.
```
  File "/home/s6xy/.local/lib/python3.7/site-packages/slack_cleaner/cli.py", line 333, in matches
    names = [get_user(m) for m in mpims['members']]
TypeError: list indices must be integers or slices, not str
```
Since `members` is already passed to `matches()`, there's no need to look them again.