### PR TITLE
Set rate_limit_queries on the Slacker object correctly.

### DIFF
--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -32,9 +32,7 @@ with Session() as session:
   elif args.verify:
     session.verify = args.verify
 
-  slack = Slacker(args.token, session=session)
-  if hasattr(slack, 'rate_limit_retries'):
-    slack.rate_limit_retries = 2
+  slack = Slacker(args.token, session=session, rate_limit_retries=2)
 
 # So we can print slack's object beautifully
 pp = pprint.PrettyPrinter(indent=4)


### PR DESCRIPTION
Slacker passes this argument down to helper objects in its __init__ function
https://github.com/os/slacker/blob/master/slacker/__init__.py#L1186 so setting it on the object after init has already run does not actually cause any retries to happen.
